### PR TITLE
Upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/monthly_update.yml
+++ b/.github/workflows/monthly_update.yml
@@ -37,10 +37,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
This PR upgrades the GitHub Actions used in the `monthly_update.yml` workflow to versions that support the Node.js 24 runtime.

- `actions/checkout@v4` -> `actions/checkout@v5`
- `actions/setup-python@v5` -> `actions/setup-python@v6`

These changes address the deprecation of Node.js 20 on GitHub Actions runners. All project tests passed locally after the modification.

---
*PR created automatically by Jules for task [14580500762335522451](https://jules.google.com/task/14580500762335522451) started by @baobabprince*