### PR TITLE
Improve scraping resilience and efficiency

### DIFF
--- a/src/engine.py
+++ b/src/engine.py
@@ -1,6 +1,7 @@
 import requests
 import time
 import random
+from urllib.parse import urlparse, urlunparse, parse_qs, urlencode
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from src.scraper import Scraper
 import threading

--- a/src/engine.py
+++ b/src/engine.py
@@ -207,7 +207,6 @@ class ScraperEngine:
         return added
 
     def crawl(self, start_url, limit=100):
-        from urllib.parse import urlparse, parse_qs
         parsed_url = urlparse(start_url)
         start_id = parse_qs(parsed_url.query).get('i', [None])[0]
 

--- a/src/engine.py
+++ b/src/engine.py
@@ -1,5 +1,6 @@
 import requests
 import time
+import random
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from src.scraper import Scraper
 import threading
@@ -21,6 +22,48 @@ class ScraperEngine:
     def scrape_person(self, url):
         result = self._scrape_one(url)
         return result[0] if result else None
+
+    def _request_with_retry(self, url, max_retries=3, backoff_factor=5):
+        for attempt in range(max_retries + 1):
+            try:
+                if self.delay > 0:
+                    time.sleep(self.delay)
+
+                response = self.session.get(url, timeout=30)
+
+                if response.status_code == 429:
+                    reason = "Rate limited (429)"
+                elif response.status_code in [500, 502, 503, 504]:
+                    reason = f"Server error ({response.status_code})"
+                else:
+                    response.raise_for_status()
+                    return response
+
+                if attempt < max_retries:
+                    sleep_time = backoff_factor * (2 ** attempt) + random.uniform(0, 1)
+                    print(f"{reason} for {url} (Attempt {attempt+1}/{max_retries+1}). Retrying in {sleep_time:.2f}s...")
+                    time.sleep(sleep_time)
+                    continue
+                else:
+                    print(f"{reason} for {url}. Max retries reached.")
+                    return None
+
+            except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+                if attempt < max_retries:
+                    sleep_time = backoff_factor * (2 ** attempt) + random.uniform(0, 1)
+                    print(f"Connection error/Timeout ({type(e).__name__}) for {url} (Attempt {attempt+1}/{max_retries+1}). Retrying in {sleep_time:.2f}s...")
+                    time.sleep(sleep_time)
+                    continue
+                else:
+                    print(f"Failed to connect to {url} after {max_retries+1} attempts: {type(e).__name__}")
+                    return None
+            except requests.exceptions.RequestException as e:
+                print(f"HTTP error for {url}: {e}")
+                return None
+            except Exception as e:
+                print(f"Unexpected error requesting {url}: {e}")
+                return None
+        return None
 
     def retry_failed(self, limit=100):
         pending = self.db.get_pending_urls()
@@ -91,77 +134,41 @@ class ScraperEngine:
 
     def _scrape_one(self, url):
         url = url.replace('//?', '/?')
-        retries = 3
-        backoff = 5
-        for attempt in range(retries + 1):
-            try:
-                # Add delay before request to be respectful
-                if self.delay > 0:
-                    time.sleep(self.delay)
-                
-                try:
-                    response = self.session.get(url, timeout=30)
-                except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
-                    if attempt < retries:
-                        print(f"Connection error/Timeout ({type(e).__name__}) for {url} (Attempt {attempt+1}/{retries+1}). Retrying...")
-                        time.sleep(backoff)
-                        continue
-                    else:
-                        print(f"Failed to connect to {url} after {retries+1} attempts: {type(e).__name__}")
-                        return None
+        response = self._request_with_retry(url)
+        if not response:
+            return None
 
-                if response.status_code == 429:
-                    if attempt < retries:
-                        sleep_time = backoff ** (attempt + 1)
-                        print(f"Rate limited (429). Retrying {url} in {sleep_time}s...")
-                        time.sleep(sleep_time)
-                        continue
-                    else:
-                        print(f"Rate limited (429). Max retries reached for {url}")
-                        return None
-                        
-                response.raise_for_status()
-                
-                html_content = response.text
-                if not html_content:
-                    print(f"Received empty response from {url}")
-                    return None
-                
-                # Extract biographical data
-                data = self.scraper.extract_biographical_data(html_content, url)
-                if data and data.get("id"):
-                    person_id = data["id"]
-                    
-                    with self.lock:
-                        if person_id in self.visited_ids:
-                            return None
-                        self.visited_ids.add(person_id)
-
-                    self.db.add_individual(data)
-                    
-                    # Extract relationships
-                    rels = self.scraper.extract_relationships(html_content, person_id, base_url=url)
-                    for rel in rels:
-                        self.db.add_relationship(rel["person_id"], rel["related_id"], rel["type"])
-                        # Always save discovered URL to DB for future crawling/retries
-                        self.db.add_discovered_url(rel["related_id"], rel["url"])
-                        
-                    return data, rels
-                else:
-                    if attempt < retries:
-                         continue
-                    return None
-
-            except requests.exceptions.RequestException as e:
-                print(f"HTTP error scraping {url} (Attempt {attempt+1}/{retries+1}): {type(e).__name__}: {e}")
-                if attempt < retries:
-                    time.sleep(backoff)
-                else:
-                    return None
-            except Exception as e:
-                print(f"Unexpected error scraping {url}: {type(e).__name__}: {e}")
+        try:
+            html_content = response.text
+            if not html_content:
+                print(f"Received empty response from {url}")
                 return None
-        return None
+
+            # Extract biographical data
+            data = self.scraper.extract_biographical_data(html_content, url)
+            if data and data.get("id"):
+                person_id = data["id"]
+                
+                with self.lock:
+                    if person_id in self.visited_ids:
+                        return None
+                    self.visited_ids.add(person_id)
+
+                self.db.add_individual(data)
+                
+                # Extract relationships
+                rels = self.scraper.extract_relationships(html_content, person_id, base_url=url)
+                for rel in rels:
+                    self.db.add_relationship(rel["person_id"], rel["related_id"], rel["type"])
+                    # Always save discovered URL to DB for future crawling/retries
+                    self.db.add_discovered_url(rel["related_id"], rel["url"])
+                    
+                return data, rels
+            else:
+                return None
+        except Exception as e:
+            print(f"Unexpected error scraping {url}: {type(e).__name__}: {e}")
+            return None
 
     def _discover_from_db(self, limit=1000):
         """Try to find missing URLs by looking at relationships of already visited people."""
@@ -200,8 +207,14 @@ class ScraperEngine:
         return added
 
     def crawl(self, start_url, limit=100):
+        from urllib.parse import urlparse, parse_qs
+        parsed_url = urlparse(start_url)
+        start_id = parse_qs(parsed_url.query).get('i', [None])[0]
+
         # Initial scrape to start the process
-        first_res = self._scrape_one(start_url)
+        first_res = None
+        if start_id not in self.visited_ids:
+            first_res = self._scrape_one(start_url)
         
         count = 0
         if first_res:

--- a/tests/test_engine_robustness.py
+++ b/tests/test_engine_robustness.py
@@ -1,0 +1,99 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import requests
+from src.engine import ScraperEngine
+from src.database import DatabaseHelper
+import time
+
+@pytest.fixture
+def mock_db(tmp_path):
+    db_path = tmp_path / "test_robustness.db"
+    return DatabaseHelper(str(db_path))
+
+def test_exponential_backoff_and_jitter_on_5xx(mock_db):
+    with patch("requests.Session.get") as mock_get, patch("time.sleep") as mock_sleep:
+        # Mock two 500 errors then a 200 OK
+        mock_500 = MagicMock()
+        mock_500.status_code = 500
+
+        mock_200 = MagicMock()
+        mock_200.status_code = 200
+        mock_200.text = '<div class="person"><div class="info"><h2>Robust Test</h2></div></div>'
+
+        mock_get.side_effect = [mock_500, mock_500, mock_200]
+
+        engine = ScraperEngine(mock_db, delay=0)
+        result = engine._scrape_one("http://example.com/?i=robust1")
+
+        assert result is not None
+        assert mock_get.call_count == 3
+        # mock_sleep called for each retry (attempt 0 and 1)
+        # and also for self.delay (which is 0, so maybe not called or called with 0)
+        # In _request_with_retry: if self.delay > 0: time.sleep(self.delay) -> not called
+        # Then after 429/500: time.sleep(sleep_time) -> called twice
+        assert mock_sleep.call_count == 2
+
+        # Check backoff timing
+        # 1st retry: 5 * (2**0) + jitter = 5 + jitter
+        # 2nd retry: 5 * (2**1) + jitter = 10 + jitter
+        calls = [args[0] for args, kwargs in mock_sleep.call_args_list]
+        assert 5 <= calls[0] <= 6
+        assert 10 <= calls[1] <= 11
+
+def test_persistent_429_max_retries(mock_db):
+    with patch("requests.Session.get") as mock_get, patch("time.sleep") as mock_sleep:
+        # Consistently return 429
+        mock_429 = MagicMock()
+        mock_429.status_code = 429
+        mock_get.return_value = mock_429
+
+        engine = ScraperEngine(mock_db, delay=0)
+        result = engine._scrape_one("http://example.com/?i=fail429")
+
+        assert result is None
+        # 1 initial + 3 retries = 4 attempts
+        assert mock_get.call_count == 4
+        assert mock_sleep.call_count == 3
+
+def test_connection_error_retries(mock_db):
+    with patch("requests.Session.get") as mock_get, patch("time.sleep") as mock_sleep:
+        mock_200 = MagicMock()
+        mock_200.status_code = 200
+        mock_200.text = '<div class="person"><div class="info"><h2>Connection Test</h2></div></div>'
+
+        mock_get.side_effect = [requests.exceptions.ConnectionError("Failed"), mock_200]
+
+        engine = ScraperEngine(mock_db, delay=0)
+        result = engine._scrape_one("http://example.com/?i=conn1")
+
+        assert result is not None
+        assert mock_get.call_count == 2
+        assert mock_sleep.call_count == 1
+
+def test_crawl_skips_visited(mock_db):
+    # Pre-populate visited_ids
+    mock_db.add_individual({
+        "id": "visited1", "name": "Already Visited", "first_name": "Already", "last_name": "Visited",
+        "prefix": None, "suffix": None, "birth_date": None, "birth_date_civil": None, "birth_place": None,
+        "death_date": None, "death_date_civil": None, "death_place": None, "gender": "M", "url": "http://example.com/?i=visited1"
+    })
+
+    with patch("src.engine.ScraperEngine._scrape_one") as mock_scrape, \
+         patch("requests.Session.get") as mock_get:
+
+        # Mock resume response for relationships
+        mock_res = MagicMock()
+        mock_res.status_code = 200
+        mock_res.text = '<div class="person"></div>' # No new rels for simplicity
+        mock_get.return_value = mock_res
+
+        engine = ScraperEngine(mock_db, delay=0)
+        # Need to refresh visited_ids since it was added directly to DB
+        engine.visited_ids = set(mock_db.get_all_ids())
+
+        engine.crawl("http://example.com/?i=visited1", limit=1)
+
+        # _scrape_one should NOT be called for visited1
+        mock_scrape.assert_not_called()
+        # But session.get might be called in the resume logic
+        assert mock_get.call_count == 1


### PR DESCRIPTION
I have significantly improved the scraping step by implementing a more robust retry mechanism in the `ScraperEngine`. 

Highlights of the changes:
- **Exponential Backoff and Jitter:** Added a centralized request method that automatically retries on 429 (Rate Limited), 5xx (Server Errors), and Connection/Timeout errors. Each retry wait time increases exponentially and includes a random jitter to prevent "thundering herd" issues.
- **Improved Crawl Efficiency:** The engine now extracts the person ID from the start URL before scraping, allowing it to skip the initial request if that individual has already been visited. This makes resuming large crawls much faster.
- **Enhanced Logging:** Added detailed console output to track retry attempts, indicating the specific error and the wait time before the next try.
- **Robust Testing:** Created a new test suite, `tests/test_engine_robustness.py`, which uses mocks to verify that backoff timings and retry logic work correctly under simulated failure conditions.

All 54 tests passed successfully.

---
*PR created automatically by Jules for task [5660929887128108046](https://jules.google.com/task/5660929887128108046) started by @baobabprince*