### PR TITLE
Improve scraper robustness and discovery of new individuals

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -33,11 +33,17 @@ class DatabaseHelper:
         cursor.execute("""
             CREATE TABLE IF NOT EXISTS discovered_urls (
                 id TEXT PRIMARY KEY,
-                url TEXT
+                url TEXT,
+                failure_count INTEGER DEFAULT 0
             )
         """)
 
         # Ensure all columns exist (simple migration)
+        cursor.execute("PRAGMA table_info(discovered_urls)")
+        existing_discovered_columns = [row[1] for row in cursor.fetchall()]
+        if "failure_count" not in existing_discovered_columns:
+            cursor.execute("ALTER TABLE discovered_urls ADD COLUMN failure_count INTEGER DEFAULT 0")
+
         cursor.execute("PRAGMA table_info(individuals)")
         existing_columns = [row[1] for row in cursor.fetchall()]
         required_columns = [
@@ -128,16 +134,43 @@ class DatabaseHelper:
             """, (person_id, url))
             self.conn.commit()
 
-    def get_pending_urls(self):
+    def get_pending_urls(self, max_failures=3):
         with self.lock:
             cursor = self.conn.cursor()
             cursor.execute("""
                 SELECT d.id, d.url 
                 FROM discovered_urls d
                 LEFT JOIN individuals i ON d.id = i.id
-                WHERE i.id IS NULL
-            """)
+                WHERE i.id IS NULL AND d.failure_count < ?
+            """, (max_failures,))
             return [dict(row) for row in cursor.fetchall()]
+
+    def increment_failure_count(self, person_id):
+        with self.lock:
+            cursor = self.conn.cursor()
+            cursor.execute("""
+                UPDATE discovered_urls
+                SET failure_count = failure_count + 1
+                WHERE id = ?
+            """, (person_id,))
+            self.conn.commit()
+
+    def reset_failure_count(self, person_id):
+        with self.lock:
+            cursor = self.conn.cursor()
+            cursor.execute("""
+                UPDATE discovered_urls
+                SET failure_count = 0
+                WHERE id = ?
+            """, (person_id,))
+            self.conn.commit()
+
+    def get_max_id(self):
+        with self.lock:
+            cursor = self.conn.cursor()
+            cursor.execute("SELECT MAX(CAST(id AS INTEGER)) FROM individuals")
+            row = cursor.fetchone()
+            return row[0] if row and row[0] else 0
 
     def close(self):
         self.conn.close()

--- a/src/engine.py
+++ b/src/engine.py
@@ -134,14 +134,21 @@ class ScraperEngine:
 
     def _scrape_one(self, url):
         url = url.replace('//?', '/?')
+        parsed_url = urlparse(url)
+        person_id = parse_qs(parsed_url.query).get('i', [None])[0]
+
         response = self._request_with_retry(url)
         if not response:
+            if person_id:
+                self.db.increment_failure_count(person_id)
             return None
 
         try:
             html_content = response.text
             if not html_content:
                 print(f"Received empty response from {url}")
+                if person_id:
+                    self.db.increment_failure_count(person_id)
                 return None
 
             # Extract biographical data
@@ -155,6 +162,7 @@ class ScraperEngine:
                     self.visited_ids.add(person_id)
 
                 self.db.add_individual(data)
+                self.db.reset_failure_count(person_id)
                 
                 # Extract relationships
                 rels = self.scraper.extract_relationships(html_content, person_id, base_url=url)
@@ -165,9 +173,13 @@ class ScraperEngine:
                     
                 return data, rels
             else:
+                if person_id:
+                    self.db.increment_failure_count(person_id)
                 return None
         except Exception as e:
             print(f"Unexpected error scraping {url}: {type(e).__name__}: {e}")
+            if person_id:
+                self.db.increment_failure_count(person_id)
             return None
 
     def _discover_from_db(self, limit=1000):
@@ -203,6 +215,44 @@ class ScraperEngine:
             
         if added > 0:
             print(f"Heuristically discovered {added} URLs from existing relationships in database.")
+        return added
+
+    def _probe_new_ids(self, base_url, limit=100, lookahead=500):
+        """Probe for new IDs starting from the max ID in database."""
+        max_id = self.db.get_max_id()
+        try:
+            max_id_int = int(max_id)
+        except (ValueError, TypeError):
+            max_id_int = 0
+
+        added = 0
+        parsed = urlparse(base_url)
+
+        # We'll probe IDs from max_id_int + 1 up to max_id_int + lookahead
+        # But we only add those that are not in visited_ids and not in pending_ids
+        for i in range(1, lookahead + 1):
+            if added >= limit:
+                break
+
+            probe_id = str(max_id_int + i)
+            with self.lock:
+                if probe_id in self.visited_ids or probe_id in self.pending_ids:
+                    continue
+
+            query = parse_qs(parsed.query)
+            query['i'] = [probe_id]
+            new_query = urlencode(query, doseq=True)
+            new_url = urlunparse((parsed.scheme, parsed.netloc, parsed.path, parsed.params, new_query, parsed.fragment))
+
+            # We don't add to DB yet, just to the queue for checking
+            with self.lock:
+                if probe_id not in self.pending_ids:
+                    self.pending_ids.add(probe_id)
+                    self.queue.put((probe_id, new_url))
+                    added += 1
+
+        if added > 0:
+            print(f"Probing {added} new IDs starting from {max_id_int + 1}...")
         return added
 
     def crawl(self, start_url, limit=100):
@@ -276,6 +326,13 @@ class ScraperEngine:
                 return
 
         if count < limit:
+            # First pass with existing queue
             count += self._process_queue(limit=limit - count)
             
+            # If still below limit, try probing for new IDs
+            if count < limit:
+                self._probe_new_ids(start_url, limit=limit - count)
+                if self.queue.qsize() > 0:
+                    count += self._process_queue(limit=limit - count)
+
         print(f"Crawl finished. Total individuals scraped in this session: {count}")

--- a/tests/test_engine_robustness.py
+++ b/tests/test_engine_robustness.py
@@ -94,6 +94,9 @@ def test_crawl_skips_visited(mock_db):
         engine.crawl("http://example.com/?i=visited1", limit=1)
 
         # _scrape_one should NOT be called for visited1
-        mock_scrape.assert_not_called()
+        for call_args in mock_scrape.call_args_list:
+            args, kwargs = call_args
+            assert "i=visited1" not in args[0]
+
         # But session.get might be called in the resume logic
         assert mock_get.call_count == 1


### PR DESCRIPTION
I've implemented several improvements to the scraper to address the issues you've been having:

1. **Failure Tracking**: I added a mechanism to track how many times a specific URL has failed. If a URL fails 3 times (after all internal retries), it will be skipped in future crawls. This prevents the scraper from getting stuck on "dead" or broken links that cause the ReadTimeout and 500 errors you saw.
2. **New Person Discovery (Probing)**: I added a new heuristic that finds the highest ID currently in your database and "probes" for higher IDs. This allows the scraper to find newly added people even if they aren't yet connected to the branches we've already scraped.
3. **Resilient Crawling**: The crawling logic now uses this probing mechanism automatically if it finishes the current queue but hasn't reached your requested limit.

These changes should help you find the new people added to the tree while avoiding the problematic URLs that were slowing things down.

---
*PR created automatically by Jules for task [10753193907410816664](https://jules.google.com/task/10753193907410816664) started by @baobabprince*