### PR TITLE
Update GitHub Actions to support Node.js 24

### DIFF
--- a/.github/workflows/monthly_update.yml
+++ b/.github/workflows/monthly_update.yml
@@ -37,10 +37,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
This change updates the GitHub Actions in `.github/workflows/monthly_update.yml` to their latest major versions (actions/checkout@v5 and actions/setup-python@v6) to ensure compatibility with the upcoming Node.js 24 runtime requirement and resolve deprecation warnings for Node.js 20.

---
*PR created automatically by Jules for task [13849315996384927718](https://jules.google.com/task/13849315996384927718) started by @baobabprince*