### PR TITLE
Normalize whitespace in names and dates

### DIFF
--- a/src/gedcom_exporter.py
+++ b/src/gedcom_exporter.py
@@ -1,4 +1,5 @@
 import sqlite3
+from src.utils import normalize_whitespace
 
 class GedcomExporter:
     def __init__(self, db_helper):
@@ -95,7 +96,7 @@ class GedcomExporter:
                 suffix = row['suffix'] or ""
                 
                 if first_name or last_name:
-                    name_line = f"1 NAME {first_name} /{last_name}/".replace("  ", " ").strip()
+                    name_line = normalize_whitespace(f"1 NAME {first_name} /{last_name}/")
                     if suffix:
                         name_line += f" {suffix}"
                     f.write(f"{name_line}\n")

--- a/src/name_parser.py
+++ b/src/name_parser.py
@@ -1,4 +1,5 @@
 import re
+from src.utils import normalize_whitespace
 
 class NameParser:
     def __init__(self):
@@ -64,7 +65,7 @@ class NameParser:
         
         # Clean the name from ALL titles
         name = self.title_regex.sub('', name).strip()
-        name = re.sub(r'\s{2,}', ' ', name)
+        name = normalize_whitespace(name)
 
         last_name = None
         last_name_match = re.search(r'\[(.*?)\]', name)

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -66,7 +66,7 @@ class Scraper:
                 data["death_date"] = normalize_whitespace(text.replace('תאריך פטירה:', '').strip())
                 data["death_date_civil"] = hebrew_to_civil(data["death_date"])
             elif 'מקום פטירה' in text:
-                data["death_place"] = normalize_whitespace(text.replace('מקום פטירה:', '').strip())
+                data["death_place"] = normalize_whitespace(text.replace('מקום פטירה:', ''))
                 
         # Explicit gender detection from class overrides name detection
         classes = person_container.get('class', [])

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -63,7 +63,7 @@ class Scraper:
             elif 'מקום לידה' in text:
                 data["birth_place"] = normalize_whitespace(text.replace('מקום לידה:', ''))
             elif 'תאריך פטירה' in text:
-                data["death_date"] = normalize_whitespace(text.replace('תאריך פטירה:', '').strip())
+                data["death_date"] = normalize_whitespace(text.replace('תאריך פטירה:', ''))
                 data["death_date_civil"] = hebrew_to_civil(data["death_date"])
             elif 'מקום פטירה' in text:
                 data["death_place"] = normalize_whitespace(text.replace('מקום פטירה:', ''))

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -58,7 +58,7 @@ class Scraper:
         for li in info_container.find_all('li'):
             text = li.get_text(strip=True)
             if 'תאריך לידה' in text:
-                data["birth_date"] = normalize_whitespace(text.replace('תאריך לידה:', '').strip())
+                data["birth_date"] = normalize_whitespace(text.replace('תאריך לידה:', ''))
                 data["birth_date_civil"] = hebrew_to_civil(data["birth_date"])
             elif 'מקום לידה' in text:
                 data["birth_place"] = normalize_whitespace(text.replace('מקום לידה:', '').strip())

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -1,7 +1,7 @@
 from bs4 import BeautifulSoup
 import re
 from urllib.parse import urlparse, parse_qs
-from src.utils import hebrew_to_civil
+from src.utils import hebrew_to_civil, normalize_whitespace
 from src.name_parser import NameParser
 
 class Scraper:
@@ -30,7 +30,7 @@ class Scraper:
             return None
 
         name_elem = info_container.find('h2')
-        name = name_elem.get_text(strip=True) if name_elem else ""
+        name = normalize_whitespace(name_elem.get_text(strip=True)) if name_elem else ""
         
         # Detect gender using NameParser
         gender = self.name_parser.detect_gender(name) or "M" # Default to M if unknown
@@ -58,15 +58,15 @@ class Scraper:
         for li in info_container.find_all('li'):
             text = li.get_text(strip=True)
             if 'תאריך לידה' in text:
-                data["birth_date"] = text.replace('תאריך לידה:', '').strip()
+                data["birth_date"] = normalize_whitespace(text.replace('תאריך לידה:', '').strip())
                 data["birth_date_civil"] = hebrew_to_civil(data["birth_date"])
             elif 'מקום לידה' in text:
-                data["birth_place"] = text.replace('מקום לידה:', '').strip()
+                data["birth_place"] = normalize_whitespace(text.replace('מקום לידה:', '').strip())
             elif 'תאריך פטירה' in text:
-                data["death_date"] = text.replace('תאריך פטירה:', '').strip()
+                data["death_date"] = normalize_whitespace(text.replace('תאריך פטירה:', '').strip())
                 data["death_date_civil"] = hebrew_to_civil(data["death_date"])
             elif 'מקום פטירה' in text:
-                data["death_place"] = text.replace('מקום פטירה:', '').strip()
+                data["death_place"] = normalize_whitespace(text.replace('מקום פטירה:', '').strip())
                 
         # Explicit gender detection from class overrides name detection
         classes = person_container.get('class', [])

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -61,7 +61,7 @@ class Scraper:
                 data["birth_date"] = normalize_whitespace(text.replace('תאריך לידה:', ''))
                 data["birth_date_civil"] = hebrew_to_civil(data["birth_date"])
             elif 'מקום לידה' in text:
-                data["birth_place"] = normalize_whitespace(text.replace('מקום לידה:', '').strip())
+                data["birth_place"] = normalize_whitespace(text.replace('מקום לידה:', ''))
             elif 'תאריך פטירה' in text:
                 data["death_date"] = normalize_whitespace(text.replace('תאריך פטירה:', '').strip())
                 data["death_date_civil"] = hebrew_to_civil(data["death_date"])

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,11 @@
 import re
 from pyluach.dates import HebrewDate, GregorianDate
 
+def normalize_whitespace(text):
+    if not text:
+        return text
+    return " ".join(text.split())
+
 HEBREW_MONTHS = {
     "ניסן": 1,
     "אייר": 2,

--- a/tests/test_double_spaces.py
+++ b/tests/test_double_spaces.py
@@ -1,0 +1,23 @@
+import pytest
+from src.utils import normalize_whitespace, parse_hebrew_date, hebrew_to_civil
+from src.name_parser import NameParser
+
+def test_normalize_whitespace():
+    assert normalize_whitespace("  hello   world  ") == "hello world"
+    assert normalize_whitespace("שניאור  זלמן") == "שניאור זלמן"
+    assert normalize_whitespace(None) is None
+
+def test_name_parser_double_spaces():
+    parser = NameParser()
+    res = parser.parse_name("  שניאור   זלמן   [מלאדי]  ")
+    assert res["first_name"] == "שניאור זלמן"
+    assert res["last_name"] == "מלאדי"
+
+def test_date_parsing_double_spaces():
+    # parse_hebrew_date uses split() which already handles double spaces
+    res = parse_hebrew_date("ט'  בכסלו   תרנ\"ד")
+    assert res["day"] == 9
+    assert res["month"] == 9
+    assert res["year"] == 5654
+
+    assert hebrew_to_civil("ט'  בכסלו   תרנ\"ד") == "18 Nov 1893"


### PR DESCRIPTION
The changes ensure that all scraped and exported genealogical data is free from redundant whitespace. This was achieved by:
1. Implementing `normalize_whitespace` in `src/utils.py`.
2. Refactoring `src/name_parser.py` to use the new utility.
3. Updating `src/scraper.py` to normalize fields during extraction.
4. Enhancing `src/gedcom_exporter.py` to produce clean GEDCOM NAME records.
5. Adding a new test file `tests/test_double_spaces.py` and verifying all tests pass.

---
*PR created automatically by Jules for task [3738946109020921666](https://jules.google.com/task/3738946109020921666) started by @baobabprince*